### PR TITLE
Update the C# extension publisher name

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "mjmcloug.vscode-elixir",
         "ms-python.python",
         "ms-vscode.Go",
-        "ms-vscode.csharp",
+        "ms-dotnettools.csharp",
         "msjsdiag.debugger-for-chrome",
         "natewallace.angular2-inline",
         "naumovs.color-highlight",


### PR DESCRIPTION
Hi, 

I work on the C# extension for VS Code. We see that this extension has a dependency on our C# extension. We wanted to inform you of our intent to change the account we publish the extension under from ‘ms-vscode’ to ‘ms-dotnettools’ on March 2nd. 

Extensions referencing our extension using the ‘ms-vscode’ publisher should still continue to work after the transition. However, it would be best to publish an update to your extension where you reference us with the new ‘ms-dotnettools’ publisher name after that time

Thanks
-Joey